### PR TITLE
Fixing issue with empty sub-concepts

### DIFF
--- a/bbva2pandas/extractor.py
+++ b/bbva2pandas/extractor.py
@@ -1,24 +1,11 @@
 import re
 
-YEAR_FIND_REGEX = re.compile(r'EXTRACTO DE \w* (\d{4})', re.MULTILINE)
-
+YEAR_FIND_REGEX = re.compile(r"EXTRACTO DE \w* (\d{4})", re.MULTILINE)
 MOVEMENTS_PARSE_REGEX = re.compile(
-    r'''^
-    (\d\d/\d\d) #date
-    \s
-    (\d\d/\d\d) #value date
-    \s*
-    ([\wÀ-ÿ .,:*%\'\/()\-\\]+?) #concept
-    \s+
-    (-?\d*.?\d*,\d*) #amount of the movement
-    \s*
-    (\d*.?\d*,\d*) #balance after movement
-    \s*
-    (\d*) # credit card number
-    \s*
-    ([\wÀ-ÿ .,:*%\'\/()\-\\]*) # subconcept
-    $''',
-    re.MULTILINE | re.IGNORECASE | re.VERBOSE
+    r"^(\d\d/\d\d)\s(\d\d/\d\d)\s*([\wÀ-ÿ .,:*%\'/()\-\\]+?)"
+    r"\s*(-?\d*.?\d*,\d\d)\s*(\d*.?\d*,\d\d)\s*(?:\n\s+"
+    r"(\d*)?\s*([\wÀ-ÿ .,:*%\'/()\-\\]*))?$",
+    re.MULTILINE | re.IGNORECASE | re.VERBOSE,
 )
 
 

--- a/tests/data/pdf-content.txt
+++ b/tests/data/pdf-content.txt
@@ -4,10 +4,13 @@
  Titulares:      JOHN DOE GARCIA
 F.Oper.       F.Valor                                         Concepto                                   Importe                    Saldo
                           SALDO ANTERIOR - - - - - - - - - - - - - - - - - - - - -                                                              0,00
-05/08 05/08               TRANSFERENCIAS                                                                         42,00                        42,00
-                           X
+05/08 05/08            TRANSFERENCIAS                                                                         42,00                        42,00
+                            X
 12/08 10/08            COMPRA EN COMERCIO EXTRANJERO-COMISIÓN 3 % INCLUÍDA                                                         -8,79                      13,55
                             LIDL BCN-CAN BATLL\ BARCELONA
+02/05 02/05            TRASPASO                                                                                                            800,00                            984,57
+02/05 02/05            TRASPASO                                                                                                           -800,00                            184,57
+                            4940197136209771 PERSONA X
    Todos los importes de este extracto se expresan en:                             SALDO A NUESTRO FAVOR               SALDO A SU FAVOR
    EURO                                                                                                                                42,00
                                                                                                                                             F12345

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -5,19 +5,36 @@ from bbva2pandas import extractor
 
 class TestExtractor(unittest.TestCase):
     def test_year_extraction(self):
-        with open('tests/data/pdf-content.txt', encoding='utf-8') as f:
-            input = f.read()
-        year = extractor.find_year(input)
-        self.assertEqual('2050', year)
+        with open("tests/data/pdf-content.txt", encoding="utf-8") as f:
+            text = f.read()
+        year = extractor.find_year(text)
+        self.assertEqual("2050", year)
 
     def test_movements_extraction(self):
-        with open('tests/data/pdf-content.txt', encoding='utf-8') as f:
-            input = f.read()
-        movements = extractor.find_movements(input)
-        expected = [('05/08', '05/08',
-                     'TRANSFERENCIAS', '42,00',
-                     '42,00', '', 'X'),
-                    ('12/08', '10/08', 'COMPRA EN COMERCIO EXTRANJERO-COMISIÓN 3 % INCLUÍDA', '-8,79', '13,55', '',
-                     'LIDL BCN-CAN BATLL\ BARCELONA')]
-        self.assertEqual(2, len(movements))
+        with open("tests/data/pdf-content.txt", encoding="utf-8") as f:
+            text = f.read()
+        movements = extractor.find_movements(text)
+        expected = [
+            ("05/08", "05/08", "TRANSFERENCIAS", "42,00", "42,00", "", "X"),
+            (
+                "12/08",
+                "10/08",
+                "COMPRA EN COMERCIO EXTRANJERO-COMISIÓN 3 % INCLUÍDA",
+                "-8,79",
+                "13,55",
+                "",
+                "LIDL BCN-CAN BATLL\ BARCELONA",
+            ),
+            ("02/05", "02/05", "TRASPASO", "800,00", "984,57", "", ""),
+            (
+                "02/05",
+                "02/05",
+                "TRASPASO",
+                "-800,00",
+                "184,57",
+                "4940197136209771",
+                "PERSONA X",
+            ),
+        ]
+        self.assertEqual(4, len(movements))
         self.assertEqual(expected, movements)


### PR DESCRIPTION
Movements like 
```
02/05 02/05 TRASPASO 800,00 984,57
```
that were missing a sub-concept were not really detected.